### PR TITLE
Add support for DoubleEndedIterator over lists and objects

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -1,6 +1,6 @@
 use std::collections::btree_map;
 use std::slice;
-use std::iter::Iterator;
+use std::iter::{Iterator, DoubleEndedIterator};
 use JsonValue;
 
 pub enum Members<'a> {
@@ -34,12 +34,30 @@ impl<'a> Iterator for Members<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for Members<'a> {
+    fn next_back(&mut self) -> Option<&'a JsonValue> {
+        match *self {
+            Members::Some(ref mut iter) => iter.next_back(),
+            Members::None               => None,
+        }
+    }
+}
+
 impl<'a> Iterator for MembersMut<'a> {
     type Item = &'a mut JsonValue;
 
     fn next(&mut self) -> Option<&'a mut JsonValue> {
         match *self {
             MembersMut::Some(ref mut iter) => iter.next(),
+            MembersMut::None               => None,
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for MembersMut<'a> {
+    fn next_back(&mut self) -> Option<&'a mut JsonValue> {
+        match *self {
+            MembersMut::Some(ref mut iter) => iter.next_back(),
             MembersMut::None               => None,
         }
     }
@@ -56,12 +74,30 @@ impl<'a> Iterator for Entries<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for Entries<'a> {
+    fn next_back(&mut self) -> Option<(&'a String, &'a JsonValue)> {
+        match *self {
+            Entries::Some(ref mut iter) => iter.next_back(),
+            Entries::None               => None
+        }
+    }
+}
+
 impl<'a> Iterator for EntriesMut<'a> {
     type Item = (&'a String, &'a mut JsonValue);
 
     fn next(&mut self) -> Option<(&'a String, &'a mut JsonValue)> {
         match *self {
             EntriesMut::Some(ref mut iter) => iter.next(),
+            EntriesMut::None               => None
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for EntriesMut<'a> {
+    fn next_back(&mut self) -> Option<(&'a String, &'a mut JsonValue)> {
+        match *self {
+            EntriesMut::Some(ref mut iter) => iter.next_back(),
             EntriesMut::None               => None
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -627,6 +627,21 @@ mod unit {
     }
 
     #[test]
+    fn array_members_rev() {
+        let data = array![1, "foo"];
+
+        for member in data.members() {
+            assert!(!member.is_null());
+        }
+
+        let mut members = data.members().rev();
+
+        assert_eq!(members.next().unwrap(), "foo");
+        assert_eq!(members.next().unwrap(), 1);
+        assert!(members.next().is_none());
+    }
+
+    #[test]
     fn array_members_mut() {
         let mut data = array![Null, Null];
 
@@ -636,6 +651,20 @@ mod unit {
         }
 
         assert_eq!(data, array![100, 100]);
+    }
+
+    #[test]
+    fn array_members_mut_rev() {
+        let mut data = array![Null, Null];
+        let mut item = 100;
+
+        for member in data.members_mut().rev() {
+            assert!(member.is_null());
+            *member = item.into();
+            item += 1;
+        }
+
+        assert_eq!(data, array![item - 1, item - 2]);
     }
 
     #[test]
@@ -684,6 +713,30 @@ mod unit {
     }
 
     #[test]
+    fn object_entries_rev() {
+        let data = object!{
+            "a" => 1,
+            "b" => "foo"
+        };
+
+        for (_, value) in data.entries().rev() {
+            assert!(!value.is_null());
+        }
+
+        let mut entries = data.entries().rev();
+
+        let (key, value) = entries.next().unwrap();
+        assert_eq!(key, "b");
+        assert_eq!(value, "foo");
+
+        let (key, value) = entries.next().unwrap();
+        assert_eq!(key, "a");
+        assert_eq!(value, 1);
+
+        assert!(entries.next().is_none());
+    }
+
+    #[test]
     fn object_entries_mut() {
         let mut data = object!{
             "a" => Null,
@@ -698,6 +751,26 @@ mod unit {
         assert_eq!(data, object!{
             "a" => 100,
             "b" => 100
+        });
+    }
+
+    #[test]
+    fn object_entries_mut_rev() {
+        let mut data = object!{
+            "a" => Null,
+            "b" => Null
+        };
+        let mut item = 100;
+
+        for (_, value) in data.entries_mut().rev() {
+            assert!(value.is_null());
+            *value = item.into();
+            item += 1;
+        }
+
+        assert_eq!(data, object!{
+            "a" => item - 1,
+            "b" => item - 2
         });
     }
 


### PR DESCRIPTION
I was doing some experimenting with my JSON data and needed to reverse the list of elements. So I've tried .members().rev(), - however, it requires `DoubleEndedIterator`, which was missing. So I added one together with some simple tests.
