### PR TITLE
Issue 108

### DIFF
--- a/tests/number.rs
+++ b/tests/number.rs
@@ -126,9 +126,3 @@ fn as_fixed_point_i64() {
 fn convert_f64_precision() {
     assert_eq!(Number::from_parts(true, 4750000000000001, -18), 0.004750000000000001);
 }
-
-#[test]
-fn issue_107() {
-    let n = Number::from_parts(true, 1, -32768);
-    assert_eq!(format!("{}", n), "1e-32768");
-}

--- a/tests/print_dec.rs
+++ b/tests/print_dec.rs
@@ -1,0 +1,9 @@
+extern crate json;
+
+use json::number::Number;
+
+#[test]
+fn issue_107() {
+    let n = Number::from_parts(true, 1, -32768);
+    assert_eq!(format!("{}", n), "1e-32768");
+}

--- a/tests/print_dec.rs
+++ b/tests/print_dec.rs
@@ -7,3 +7,15 @@ fn issue_107() {
     let n = Number::from_parts(true, 1, -32768);
     assert_eq!(format!("{}", n), "1e-32768");
 }
+
+#[test]
+fn issue_108_exponent_positive() {
+    let n = Number::from_parts(true, 10_000_000_000_000_000_001, -18);
+    assert_eq!(format!("{}", n), "1.0000000000000000001e+1");
+}
+
+#[test]
+fn issue_108_exponent_0() {
+    let n = Number::from_parts(true, 10_000_000_000_000_000_001, -19);
+    assert_eq!(format!("{}", n), "1.0000000000000000001");
+}


### PR DESCRIPTION
Fixes #108.

A separate logic for handling cases where the exponent is negative, less than -18, but the base number is big enough so that adjusting the exponent when moving the decimal point makes the exponent positive (or zero).