### PR TITLE
Implement exact size iterator

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -623,6 +623,12 @@ impl<'a> DoubleEndedIterator for IterMut<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for IterMut<'a> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
 /// Implements indexing by `&str` to easily access object members:
 ///
 /// ## Example

--- a/src/object.rs
+++ b/src/object.rs
@@ -588,6 +588,12 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for Iter<'a> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
 pub struct IterMut<'a> {
     inner: slice::IterMut<'a, Node>
 }


### PR DESCRIPTION
The goal of this PR is to allow to use `ExactSizeIterator` functions (`is_empty`) on the iterators returned by `JsonValue::entries` and `JsonValue::entries_mut`.
