### PR TITLE
Use $crate when recursing in object! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ macro_rules! object {
     //
     // In this implementation, key/value pairs separated by commas.
     { $( $key:expr => $value:expr ),* } => {
-        object!( $(
+        $crate::object!( $(
             $key => $value,
         )* )
     };


### PR DESCRIPTION
This allows calling `json::object!` without having to `use json::object;`. It might raise the `rustc` version / edition requirements, I'm not sure.