### PR TITLE
Removed reference to terhix.com

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Parse and serialize [JSON](http://json.org/) with ease.
 //!
 //! **[Changelog](https://github.com/maciejhirsz/json-rust/releases) -**
-//! **[Complete Documentation](http://terhix.com/doc/json/) -**
+//! **[Complete Documentation](https://docs.rs/json/) -**
 //! **[Cargo](https://crates.io/crates/json) -**
 //! **[Repository](https://github.com/maciejhirsz/json-rust)**
 //!


### PR DESCRIPTION
Changed document link from terhix.com (which is reported to be compromised, does not show any documentation) to docs.rs.