### PR TITLE
Add as_object() and as_array() methods

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -277,6 +277,60 @@ impl JsonValue {
         }
     }
 
+    pub fn as_object(&self) -> Option<&Object> {
+        if let Self::Object(object) = self {
+            Some(object)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_object_mut(&mut self) -> Option<&mut Object> {
+        if let Self::Object(object) = self {
+            Some(object)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_array(&self) -> Option<&Vec<JsonValue>> {
+        if let Self::Array(array) = self {
+            Some(array)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<JsonValue>> {
+        if let Self::Array(array) = self {
+            Some(array)
+        } else {
+            None
+        }
+    }
+
+    /// If `self` is a `JsonValue::Object`, then this looks up an entry by its `key` in the object.
+    ///
+    /// If `self` is not a `JsonValue::Object`, then this method returns `None`.
+    pub fn get(&self, key: &str) -> Option<&JsonValue> {
+        if let Self::Object(object) = self {
+            object.get(key)
+        } else {
+            None
+        }
+    }
+
+    /// If `self` is a `JsonValue::Object`, then this looks up an entry by its `key` in the object.
+    ///
+    /// If `self` is not a `JsonValue::Object`, then this method returns `None`.
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut JsonValue> {
+        if let Self::Object(object) = self {
+            object.get_mut(key)
+        } else {
+            None
+        }
+    }
+
     /// Obtain an integer at a fixed decimal point. This is useful for
     /// converting monetary values and doing arithmetic on them without
     /// rounding errors introduced by floating point operations.

--- a/tests/value.rs
+++ b/tests/value.rs
@@ -667,3 +667,38 @@ fn equality() {
     assert_ne!(left, change_string);
     assert_ne!(left, change_short);
 }
+
+#[test]
+fn as_object() {
+    let obj = object!{ foo: ["bar"] };
+    assert!(obj.as_object().is_some());
+    assert_eq!(*obj.as_object().unwrap().get("foo").unwrap(), array!{"bar"});
+
+    assert!((array!{}).as_object().is_none());
+    assert!(JsonValue::from("string").as_object().is_none());
+}
+
+#[test]
+fn as_object_mut() {
+    let mut obj = object!{};
+    assert!(obj.as_object_mut().is_some());
+    obj.as_object_mut().unwrap().insert("foo", array!{42});
+    assert_eq!(obj, object!{foo: [42]});
+
+    assert!((array!{}).as_object_mut().is_none());
+    assert!(JsonValue::from("string").as_object_mut().is_none());
+}
+
+#[test]
+fn value_get() {
+    let obj: JsonValue = object!{ foo: 42 };
+    assert_eq!(obj.get("foo"), Some(&JsonValue::from(42)));
+    assert_eq!(obj.get("missing"), None);
+}
+
+#[test]
+fn value_get_mut() {
+    let mut obj: JsonValue = object!{ foo: [42] };
+    obj.get_mut("foo").unwrap().push(43).unwrap();
+    assert_eq!(obj, object!{ foo: [42, 43] });
+}


### PR DESCRIPTION
This adds JsonValue::as_object() and JsonValue::as_array() methods.
This provides parity with the as_u32, as_str, etc. methods. It
simplifies code that deals with objects and arrays directly,
rather than using serde for a schematized view.

Also added JsonValue::get() and JsonValue::get_mut(), which forward
their calls to Object.