### PR TITLE
Add Natvis definitions and tests for `json` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,17 @@ repository = "https://github.com/maciejhirsz/json-rust"
 documentation = "https://docs.rs/json/"
 license = "MIT/Apache-2.0"
 edition = "2018"
+
+[dev-dependencies]
+debugger_test = "0.1.0"
+debugger_test_parser = "0.1.0"
+
+[features]
+# UNSTABLE FEATURES (requires Rust nightly)
+# Enable to use the #[debugger_visualizer] attribute.
+debugger_visualizer = []
+
+[[test]]
+path = "tests/debugger_visualizer.rs"
+name = "debugger_visualizer"
+required-features = ["debugger_visualizer"]

--- a/debug_metadata/README.md
+++ b/debug_metadata/README.md
@@ -1,0 +1,111 @@
+## Debugger Visualizers
+
+Many languages and debuggers enable developers to control how a type is
+displayed in a debugger. These are called "debugger visualizations" or "debugger
+views".
+
+The Windows debuggers (WinDbg\CDB) support defining custom debugger visualizations using
+the `Natvis` framework. To use Natvis, developers write XML documents using the natvis
+schema that describe how debugger types should be displayed with the `.natvis` extension.
+(See: https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2019)
+The Natvis files provide patterns which match type names a description of how to display
+those types.
+
+The Natvis schema can be found either online (See: https://code.visualstudio.com/docs/cpp/natvis#_schema)
+or locally at `<VS Installation Folder>\Xml\Schemas\1033\natvis.xsd`.
+
+The GNU debugger (GDB) supports defining custom debugger views using Pretty Printers.
+Pretty printers are written as python scripts that describe how a type should be displayed
+when loaded up in GDB/LLDB. (See: https://sourceware.org/gdb/onlinedocs/gdb/Pretty-Printing.html#Pretty-Printing)
+The pretty printers provide patterns, which match type names, and for matching
+types, descibe how to display those types. (For writing a pretty printer, see: https://sourceware.org/gdb/onlinedocs/gdb/Writing-a-Pretty_002dPrinter.html#Writing-a-Pretty_002dPrinter).
+
+### Embedding Visualizers
+
+Through the use of the currently unstable `#[debugger_visualizer]` attribute, the `json`
+crate can embed debugger visualizers into the crate metadata.
+
+Currently the two types of visualizers supported are Natvis and Pretty printers.
+
+For Natvis files, when linking an executable with a crate that includes Natvis files,
+the MSVC linker will embed the contents of all Natvis files into the generated `PDB`.
+
+For pretty printers, the compiler will encode the contents of the pretty printer
+in the `.debug_gdb_scripts` section of the `ELF` generated.
+
+### Testing Visualizers
+
+The `json` crate supports testing debugger visualizers defined for this crate. The entry point for
+these tests are `tests/debugger_visualizer.rs`. These tests are defined using the `debugger_test` and
+`debugger_test_parser` crates. The `debugger_test` crate is a proc macro crate which defines a
+single proc macro attribute, `#[debugger_test]`. For more detailed information about this crate,
+see https://crates.io/crates/debugger_test. The CI pipeline for the `json` crate has been updated
+to run the debugger visualizer tests to ensure debugger visualizers do not become broken/stale.
+
+The `#[debugger_test]` proc macro attribute may only be used on test functions and will run the
+function under the debugger specified by the `debugger` meta item.
+
+This proc macro attribute has 3 required values:
+
+1. The first required meta item, `debugger`, takes a string value which specifies the debugger to launch.
+2. The second required meta item, `commands`, takes a string of new line (`\n`) separated list of debugger
+commands to run.
+3. The third required meta item, `expected_statements`, takes a string of new line (`\n`) separated list of
+statements that must exist in the debugger output. Pattern matching through regular expressions is also
+supported by using the `pattern:` prefix for each expected statement.
+
+#### Example:
+
+```rust
+#[debugger_test(
+    debugger = "cdb",
+    commands = "command1\ncommand2\ncommand3",
+    expected_statements = "statement1\nstatement2\nstatement3")]
+fn test() {
+
+}
+```
+
+Using a multiline string is also supported, with a single debugger command/expected statement per line:
+
+```rust
+#[debugger_test(
+    debugger = "cdb",
+    commands = "
+command1
+command2
+command3",
+    expected_statements = "
+statement1
+pattern:statement[0-9]+
+statement3")]
+fn test() {
+    
+}
+```
+
+In the example above, the second expected statement uses pattern matching through a regular expression
+by using the `pattern:` prefix.
+
+#### Testing Locally
+
+Currently, only Natvis visualizations have been defined for the `json` crate via `debug_metadata/json.natvis`,
+which means the `tests/debugger_visualizer.rs` tests need to be run on Windows using the `*-pc-windows-msvc` targets.
+To run these tests locally, first ensure the debugging tools for Windows are installed or install them following
+the steps listed here, [Debugging Tools for Windows](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/).
+Once the debugging tools have been installed, the tests can be run in the same manner as they are in the CI
+pipeline.
+
+#### Note
+
+When running the debugger visualizer tests, `tests/debugger_visualizer.rs`, they need to be run consecutively
+and not in parallel. This can be achieved by passing the flag `--test-threads=1` to rustc. This is due to
+how the debugger tests are run. Each test marked with the `#[debugger_test]` attribute launches a debugger
+and attaches it to the current test process. If tests are running in parallel, the test will try to attach
+a debugger to the current process which may already have a debugger attached causing the test to fail.
+
+For example:
+
+```
+cargo test --test debugger_visualizer --features debugger_visualizer -- --test-threads=1
+```

--- a/debug_metadata/json.natvis
+++ b/debug_metadata/json.natvis
@@ -1,0 +1,48 @@
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="json::number::Number">
+    <Intrinsic Name="pos" Expression="exponent &lt; 0 ? -exponent : exponent" />
+    <Intrinsic Name="calc_exponent" Expression="exponent == 0 ? 1 : exponent == 1 ? value : calc_exponent(exponent - 1, value * 10)">
+        <Parameter Name="exponent" Type="int" />
+        <Parameter Name="value" Type="__int64" />
+    </Intrinsic>
+    <Intrinsic Name="calc_value" Expression="exponent &lt; 0 ? ((double)mantissa / calc_exponent(pos(), 10)) : (__int64)(mantissa * calc_exponent(pos(), 10))" />
+
+    <!-- Display the value for a negative number -->
+    <DisplayString Condition="category == 0">{(-1 * calc_value()),d}</DisplayString>
+    <!-- Display the value for a positive number -->
+    <DisplayString Condition="category == 1">{calc_value(),d}</DisplayString>
+
+    <Expand>
+        <Item Name="[category]">category,d</Item>
+        <Item Name="[exponent]">exponent,d</Item>
+        <Item Name="[mantissa]">mantissa,d</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="json::object::Key">
+    <DisplayString>{(char*)ptr,[len]s8}</DisplayString>
+  </Type>
+
+  <Type Name="json::object::Node">
+    <DisplayString>{{ key={key}, value={value}}}</DisplayString>
+    <Expand>
+        <Item Name="[key]">key</Item>
+        <Item Name="[value]">value</Item>
+        <Item Name="[left]">left</Item>
+        <Item Name="[right]">right</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="json::object::Object">
+    <Expand>
+        <CustomListItems>
+            <Variable Name="i" InitialValue="0" />
+            <Size>store.len</Size>
+            <Loop>
+                <Item Name="{store[i].key}">store[i].value</Item>
+                <Exec>i++</Exec>
+            </Loop>
+        </CustomListItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,12 @@
 //! # }
 //! ```
 
+#![cfg_attr(
+    feature = "debugger_visualizer",
+    feature(debugger_visualizer),
+    debugger_visualizer(natvis_file = "../debug_metadata/json.natvis")
+)]
+
 use std::result;
 
 pub mod codegen;

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -1,0 +1,131 @@
+use debugger_test::*;
+use json::*;
+
+#[inline(never)]
+fn __break() { }
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = r#"
+.nvlist
+dx json.__0
+dx -r2 json.__0["\"positive_number\""]
+dx -r2 json.__0["\"negative_number\""]
+dx -r2 json.__0["\"float_number\""]
+dx -r3 json.__0["\"string\""]
+dx -r4 json.__0["\"array\""]
+    "#,
+    expected_statements = r#"
+json.__0         [Type: json::object::Object]
+    [<Raw View>]     [Type: json::object::Object]
+    ["\"positive_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    ["\"negative_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    ["\"float_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    ["\"string\""]   : String [Type: enum2$<json::value::JsonValue>]
+    ["\"array\""]    : Array [Type: enum2$<json::value::JsonValue>]
+json.__0["\"positive_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+    [+0x008] __0              : 10 [Type: json::number::Number]
+        [<Raw View>]     [Type: json::number::Number]
+        [category]       : 1 [Type: unsigned char]
+        [exponent]       : 0 [Type: short]
+        [mantissa]       : 10 [Type: unsigned __int64]
+json.__0["\"negative_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+    [+0x008] __0              : -250 [Type: json::number::Number]
+        [<Raw View>]     [Type: json::number::Number]
+        [category]       : 0 [Type: unsigned char]
+        [exponent]       : 0 [Type: short]
+        [mantissa]       : 250 [Type: unsigned __int64]
+json.__0["\"float_number\""] : Number [Type: enum2$<json::value::JsonValue>]
+    [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+    [+0x008] __0              : 19.210000 [Type: json::number::Number]
+        [<Raw View>]     [Type: json::number::Number]
+        [category]       : 1 [Type: unsigned char]
+        [exponent]       : -2 [Type: short]
+        [mantissa]       : 1921 [Type: unsigned __int64]
+json.__0["\"string\""] : String [Type: enum2$<json::value::JsonValue>]
+    [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+    [+0x008] __0              : "Loooooooooooooooooooooooooooong String" [Type: alloc::string::String]
+        [<Raw View>]     [Type: alloc::string::String]
+        [len]            : 0x26 [Type: unsigned __int64]
+        [capacity]       : 0x26 [Type: unsigned __int64]
+        [chars]          : "Loooooooooooooooooooooooooooong String"
+            [0]              : 76 'L' [Type: char]
+            [1]              : 111 'o' [Type: char]
+            [2]              : 111 'o' [Type: char]
+            [3]              : 111 'o' [Type: char]
+            [4]              : 111 'o' [Type: char]
+            [5]              : 111 'o' [Type: char]
+            [6]              : 111 'o' [Type: char]
+            [7]              : 111 'o' [Type: char]
+            [8]              : 111 'o' [Type: char]
+            [9]              : 111 'o' [Type: char]
+            [10]             : 111 'o' [Type: char]
+            [11]             : 111 'o' [Type: char]
+            [12]             : 111 'o' [Type: char]
+            [13]             : 111 'o' [Type: char]
+            [14]             : 111 'o' [Type: char]
+            [15]             : 111 'o' [Type: char]
+            [16]             : 111 'o' [Type: char]
+            [17]             : 111 'o' [Type: char]
+            [18]             : 111 'o' [Type: char]
+            [19]             : 111 'o' [Type: char]
+            [20]             : 111 'o' [Type: char]
+            [21]             : 111 'o' [Type: char]
+            [22]             : 111 'o' [Type: char]
+            [23]             : 111 'o' [Type: char]
+            [24]             : 111 'o' [Type: char]
+            [25]             : 111 'o' [Type: char]
+            [26]             : 111 'o' [Type: char]
+            [27]             : 111 'o' [Type: char]
+            [28]             : 111 'o' [Type: char]
+            [29]             : 110 'n' [Type: char]
+            [30]             : 103 'g' [Type: char]
+            [31]             : 32 ' ' [Type: char]
+            [32]             : 83 'S' [Type: char]
+            [33]             : 116 't' [Type: char]
+            [34]             : 114 'r' [Type: char]
+            [35]             : 105 'i' [Type: char]
+            [36]             : 110 'n' [Type: char]
+            [37]             : 103 'g' [Type: char]
+
+json.__0["\"array\""] : Array [Type: enum2$<json::value::JsonValue>]
+    [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+    [+0x008] __0              : { len=0x3 } [Type: alloc::vec::Vec<enum2$<json::value::JsonValue>,alloc::alloc::Global>]
+        [<Raw View>]     [Type: alloc::vec::Vec<enum2$<json::value::JsonValue>,alloc::alloc::Global>]
+        [len]            : 0x3 [Type: unsigned __int64]
+        [capacity]       : 0x3 [Type: unsigned __int64]
+        [0]              : Object [Type: enum2$<json::value::JsonValue>]
+            [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+            [+0x008] __0              [Type: json::object::Object]
+                [<Raw View>]     [Type: json::object::Object]
+                ["\"short\""]    : Short [Type: enum2$<json::value::JsonValue>]
+        [1]              : Boolean [Type: enum2$<json::value::JsonValue>]
+            [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+            [+0x001] __0              : true [Type: bool]
+        [2]              : Array [Type: enum2$<json::value::JsonValue>]
+            [<Raw View>]     [Type: enum2$<json::value::JsonValue>]
+            [+0x008] __0              : { len=0x1 } [Type: alloc::vec::Vec<enum2$<json::value::JsonValue>,alloc::alloc::Global>]
+                [<Raw View>]     [Type: alloc::vec::Vec<enum2$<json::value::JsonValue>,alloc::alloc::Global>]
+                [len]            : 0x1 [Type: unsigned __int64]
+                [capacity]       : 0x1 [Type: unsigned __int64]
+                [0]              : Null [Type: enum2$<json::value::JsonValue>]
+    "#
+)]
+fn test_debugger_visualizer() {
+    let json = object!{
+        positive_number: 10,
+        negative_number: -250,
+        float_number: 19.21,
+        string: "Loooooooooooooooooooooooooooong String",
+        array: [
+            object!{ short: "short string" },
+            true,
+            [null],
+        ],
+    };
+
+    assert!(json["array"][1] == true);
+    __break();
+}


### PR DESCRIPTION
This change adds Natvis visualizations for types in the `json` crate to help improve the debugging experience on Windows.

Natvis is a framework that can be used to specify how types should be viewed under a supported debugger, such as the Windows debugger (WinDbg) and the Visual Studio debugger.

The Rust compiler does have Natvis support for some types, but this is limited to some of the core libraries and not supported for external crates.

https://github.com/rust-lang/rfcs/pull/3191 proposes adding support for embedding debugging visualizations such as Natvis in a Rust crate. This RFC has been approved, merged and implemented.

This PR adds:

* Natvis visualizations for `json` types.
* Tests for testing visualizers embedded in the `json` crate.
* A new debugger_visualizer feature for the `json` crate to enable the unstable debugger_visualizer Rust feature.