### PR TITLE
Update lifetimes of `read_complex_string`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -482,7 +482,7 @@ impl<'a> Parser<'a> {
     // is whole lot slower than parsing "foobar", as the former suffers from
     // having to be read from source to a buffer and then from a buffer to
     // our target string. Nothing to be done about this, really.
-    fn read_complex_string<'b>(&mut self, start: usize) -> Result<&'b str> {
+    fn read_complex_string(&mut self, start: usize) -> Result<&'_ str> {
         // Since string slices are returned by this function that are created via pointers into `self.buffer`
         // we shouldn't be clearing or modifying the buffer in consecutive calls to this function. Instead
         // we continuously append bytes to `self.buffer` and keep track of the starting offset of the buffer on each


### PR DESCRIPTION
The lifetimes of `read_complex_string` in `parser.rs` are weird. It returns a slice, but the lifetime of the slice is not tied to either the lifetime of `self` or the lifetime of the struct.

```Rust
fn read_complex_string<'b>(&mut self, start: usize) -> Result<&'b str>
```

This could cause potential memory errors. Eg :

```Rust
let sl2;
{
  let a: String = String::from("bftb\"ftbft");
  let sl: &str = &a[0..5];
  
  let mut parser = Parser::new(sl);
  parser.bump();
  sl2 = parser.read_complex_string(0);
}
println!("{:?}", sl2); // Will print garbage because the String has been dropped
```

This signature makes more sense and passes all tests.

```Rust
fn read_complex_string(&mut self, start: usize) -> Result<&'_ str>
```